### PR TITLE
Add default path mode for `--add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@
 The `to` command facilitates shortcut management and execution.
 
 **1. Adding a Shortcut**
-Register a new shortcut using `to --add <keyword> <path> [--expire <timestamp>]` or the shorthand `to -a <keyword> <path>`. The optional `--expire` flag sets an expiration time in epoch seconds. The specified path can be relative or absolute; relative paths will be resolved to their absolute form automatically.
+Register a new shortcut using `to --add <keyword> <path> [--expire <timestamp>]`, the shorthand `to -a <keyword> <path>`, or simply `to --add <path>` which uses the directory name as the keyword automatically. The optional `--expire` flag sets an expiration time in epoch seconds. The specified path can be relative or absolute; relative paths will be resolved to their absolute form automatically.
 
 ```zsh
 ❯ to --add proj ../my-project --expire 1700000000
 Added proj → ../my-project (expires 1700000000)
+❯ to --add ../another-project
+Added another-project → ../another-project
 ```
 
 **2. Jumping to a Saved Directory**
@@ -149,6 +151,7 @@ to - Persistent Directory Shortcuts
 Usage:
   to <keyword>                       Navigate to saved shortcut
   to --add, -a <keyword> <path>      Save new shortcut
+  to --add <path>                    Save shortcut using directory name
   to --rm,  -r <keyword>             Remove existing shortcut
   to --list, -l                      List all shortcuts
   to --print-path, -p <keyword>      Print stored path only
@@ -171,7 +174,7 @@ Options:
 
 | Option              | Short | Description                         |
 |---------------------|-------|-------------------------------------|
-| `--add <k> <path>`  | `-a`  | Add a new shortcut `k` → `path`.    |
+| `--add [<k>] <path>`| `-a`  | Add a new shortcut; if `k` is omitted the directory name is used. |
 | `--rm <k>`          | `-r`  | Remove shortcut associated with `k`.|
 | `--list`            | `-l`  | List all saved shortcuts.           |
 | `--print-path <k>`  | `-p`  | Print stored or nested path using prefix matching.              |

--- a/to.zsh
+++ b/to.zsh
@@ -103,6 +103,7 @@ function To_ShowHelp {
     printf "${MAGENTA}Usage:${RESET}\n"
     printf "  ${DIM_WHITE}to <keyword>                       ${RESET}Navigate to saved shortcut\n"
     printf "  ${DIM_WHITE}to --add, -a <keyword> <path> [--expire <timestamp>]     ${RESET} Save new shortcut\n"
+    printf "  ${DIM_WHITE}to --add <path> [--expire <timestamp>]            ${RESET} Save shortcut using directory name as keyword\n"
     printf "  ${DIM_WHITE}to --rm,  -r <keyword>            ${RESET} Remove existing shortcut\n"
     printf "  ${DIM_WHITE}to --list, -l                     ${RESET} List all shortcuts\n"
     printf "  ${DIM_WHITE}to --print-path, -p <keyword>     ${RESET} Print stored path only\n"
@@ -139,6 +140,13 @@ function AddShortcut {
     local keyword="$1"
     local targetPath="$2"
     local expire="$3"
+
+    # When only one argument is provided, treat it as the path and derive
+    # the keyword from the final directory component.
+    if [ -z "${targetPath}" ]; then
+        targetPath="$keyword"
+        keyword="$(basename -- "${targetPath}")"
+    fi
 
     if [ -z "${keyword}" ] || [ -z "${targetPath}" ]; then
         printf "${BOLD_RED}Usage: to --add <keyword> <path>${RESET}\n"
@@ -327,8 +335,13 @@ function to {
                 action="add"
                 shift
                 addKeyword="$1"
-                targetPath="$2"
-                shift 2
+                if [[ $# -ge 2 && $2 != -* ]]; then
+                    targetPath="$2"
+                    shift 2
+                else
+                    targetPath=""
+                    shift 1
+                fi
                 ;;
             --expire)
                 expireTime="$2"


### PR DESCRIPTION
## Summary
- allow `to --add` to take a single path and derive the keyword from the directory name
- document new usage in help text and README

## Testing
- `shellcheck to.zsh`
- `zsh tests/test_completion.zsh`