### PR TITLE
Improve path completion in to

### DIFF
--- a/tests/test_completion.zsh
+++ b/tests/test_completion.zsh
@@ -28,5 +28,13 @@ if ! whence -f _to | grep -q -- '--no-create'; then
     echo "completion missing --no-create" >&2
     exit 1
 fi
+if ! whence -f _to | grep -q '_path_files'; then
+    echo "completion missing _path_files" >&2
+    exit 1
+fi
+if ! whence -f _to | grep -q 'GetSortedKeywords'; then
+    echo "completion missing GetSortedKeywords" >&2
+    exit 1
+fi
 
 echo "tests passed"

--- a/to.zsh
+++ b/to.zsh
@@ -552,6 +552,18 @@ if [[ -n $ZSH_VERSION ]]; then
 
         case $state in
         keywords)
+            local cur=${words[CURRENT]}
+            if [[ $cur == */* ]]; then
+                local key=${cur%%/*}
+                local rest=${cur#*/}
+                local base
+                base=$(grep -m1 "^${key}=" "${CONFIG_FILE}" 2>/dev/null | cut -d'=' -f2-)
+                if [[ -n $base ]]; then
+                    _path_files -W "$base" -/ "$rest"
+                    return
+                fi
+            fi
+
             local -a keywords
             keywords=($(GetSortedKeywords))
             compadd -- $keywords


### PR DESCRIPTION
## Summary
- update `_to` completion to support path suggestions using `_path_files`
- ensure keywords are sorted using `GetSortedKeywords`
- expand tests for completion helpers

## Testing
- `shellcheck -s sh to.zsh tests/test_completion.zsh`
- `./tests/test_completion.zsh`
