### PR TITLE
Add CLI sort override

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Usage:
   to --print-path, -p <keyword>      Print stored path only
   to --code, -c <keyword>            Open in VSCode after navigation
   to --no-create <keyword>           Jump without creating missing directories
+  to --sort, -s <mode>               Override sorting mode
   to --add <k> <path> --expire <ts>  Save shortcut with expiration
   to --help, -h                      Show this help
 
@@ -183,6 +184,7 @@ Options:
   --expire                           Set expiration epoch time
   --code, -c                         Open in VSCode
   --no-create                        Disable automatic directory creation
+  --sort, -s                         Override sorting mode
   --help, -h                         Show help
 ```
 
@@ -217,6 +219,7 @@ Saved shortcuts:
 | `--expire <ts>`     |       | Expire the shortcut after the given epoch timestamp. |
 | `--code`            | `-c`  | Run `code .` in target directory after navigation. |
 | `--no-create`       |       | Do not create nested directories on jump. |
+| `--sort <mode>`     | `-s`  | Override sorting mode (`added`, `alpha`, or `recent`). |
 | `--help`            | `-h`  | Show help message and usage.        |
 
 ## Configuration Details
@@ -229,6 +232,7 @@ Saved shortcuts:
   - `sort_order=added|alpha|recent` controls how shortcuts are listed and suggested.
     The `recent` option uses timestamps stored in `~/.to_dirs_recent` which are
     updated each time a shortcut is used.
+  - The `--sort` flag can override the configured mode for a single run.
 
 ## Contributing
 

--- a/tests/test_completion.zsh
+++ b/tests/test_completion.zsh
@@ -28,6 +28,10 @@ if ! whence -f _to | grep -q -- '--no-create'; then
     echo "completion missing --no-create" >&2
     exit 1
 fi
+if ! whence -f _to | grep -q -- '--sort'; then
+    echo "completion missing --sort" >&2
+    exit 1
+fi
 if ! whence -f _to | grep -q '_path_files'; then
     echo "completion missing _path_files" >&2
     exit 1

--- a/to.zsh
+++ b/to.zsh
@@ -16,6 +16,7 @@ CONFIG_META_FILE="${HOME}/.to_dirs_meta"
 USER_CONFIG_FILE="${HOME}/.to_zsh_config"
 RECENT_FILE="${HOME}/.to_dirs_recent"
 USER_SORT_ORDER="added"
+SORT_OVERRIDE=""
 
 # Remove expired shortcuts from storage
 function CleanupExpiredShortcuts {
@@ -56,6 +57,9 @@ function LoadUserConfig {
                     ;;
             esac
         done <"${USER_CONFIG_FILE}"
+    fi
+    if [ -n "$SORT_OVERRIDE" ]; then
+        USER_SORT_ORDER="$SORT_OVERRIDE"
     fi
 }
 
@@ -111,6 +115,7 @@ function To_ShowHelp {
     printf "  ${DIM_WHITE}%-55s${RESET}%s\n" "to --print-path, -p <keyword>" "Print stored path only"
     printf "  ${DIM_WHITE}%-55s${RESET}%s\n" "to --code, -c <keyword>" "Open in VSCode after navigation"
     printf "  ${DIM_WHITE}%-55s${RESET}%s\n" "to --no-create" "Do not create nested path on jump"
+    printf "  ${DIM_WHITE}%-55s${RESET}%s\n" "to --sort, -s <mode>" "Override sorting mode"
     printf "  ${DIM_WHITE}%-55s${RESET}%s\n\n" "to --help, -h" "Show this help"
 
     printf "${MAGENTA}Options:${RESET}\n"
@@ -124,6 +129,7 @@ function To_ShowHelp {
     printf "  ${BOLD_CYAN}%-30s${RESET}%s\n" "--expire <ts>" "Set expiration epoch for shortcut"
     printf "  ${BOLD_CYAN}%-30s${RESET}%s\n" "--code, -c" "Open in VSCode"
     printf "  ${BOLD_CYAN}%-30s${RESET}%s\n" "--no-create" "Disable path creation on jump"
+    printf "  ${BOLD_CYAN}%-30s${RESET}%s\n" "--sort, -s" "Override sorting mode"
     printf "  ${BOLD_CYAN}%-30s${RESET}%s\n" "--help, -h" "Show help"
 
     DisplaySavedShortcuts
@@ -402,6 +408,8 @@ function to {
     fi
     CleanupExpiredShortcuts
 
+    SORT_OVERRIDE=""
+
     local runCode=0
     local printPath=0
     local createFlag=1
@@ -413,6 +421,7 @@ function to {
     local bulkPattern=""
     local copyExisting=""
     local copyNew=""
+    local sortOverride=""
     local positional=()
 
     # parse flags in any position
@@ -467,6 +476,10 @@ function to {
                 createFlag=0
                 shift
                 ;;
+            --sort|-s)
+                sortOverride="$2"
+                shift 2
+                ;;
             --rm|-r)
                 action="remove"
                 shift
@@ -479,6 +492,8 @@ function to {
                 ;;
         esac
     done
+
+    SORT_OVERRIDE="$sortOverride"
 
     if [[ $printPath -eq 1 ]]; then
         # handle print-path action
@@ -566,6 +581,7 @@ if [[ -n $ZSH_VERSION ]]; then
             '--copy[copy existing shortcut]:existing keyword:->keywords :new:' \
             '--expire[expiration timestamp]:timestamp:' \
             '--no-create[do not create missing directories]' \
+            '(-s --sort)'{-s,--sort}'[override sorting]:mode:(added alpha recent)' \
             '(-r --rm)'{-r,--rm}'[remove shortcut]:keyword:->keywords' \
             '*:keyword:->keywords' && return
 


### PR DESCRIPTION
## Summary
- allow overriding sort order with `--sort`/`-s`
- document new option in README
- update autocompletion and tests

## Testing
- `shellcheck to.zsh`
- `zsh tests/test_completion.zsh`